### PR TITLE
atob() deprcated since v15.13.0/ v14.17.0

### DIFF
--- a/src/_services/account.service.js
+++ b/src/_services/account.service.js
@@ -115,7 +115,7 @@ let refreshTokenTimeout;
 
 function startRefreshTokenTimer() {
     // parse json object from base64 encoded jwt token
-    const jwtToken = JSON.parse(atob(userSubject.value.jwtToken.split('.')[1]));
+    const jwtToken = JSON.parse( Buffer.from(userSubject.value.jwtToken.split(".")[1], 'base64') );
 
     // set a timeout to refresh the token a minute before it expires
     const expires = new Date(jwtToken.exp * 1000);


### PR DESCRIPTION
This function is only provided for compatibility with legacy web platform APIs and is advised to never be used in new code, because they use strings to represent binary data and predate the introduction of typed arrays in JavaScript. For code running using APIs, converting between base64-encoded strings and binary data states that it should be performed using Buffer.from(str, 'base64') and buf.toString('base64').